### PR TITLE
Add board conversion helpers

### DIFF
--- a/src/utils/boardStorage.js
+++ b/src/utils/boardStorage.js
@@ -1,0 +1,7 @@
+export function flattenBoard(board) {
+  return board.flat().map(c => ({ value: c.value, notes: c.notes, fixed: c.fixed }));
+}
+
+export function expandBoard(flat) {
+  return Array.from({ length: 9 }, (_, r) => flat.slice(r * 9, (r + 1) * 9));
+}


### PR DESCRIPTION
## Summary
- add helpers to flatten/expand a Sudoku board

## Testing
- `npm run lint` *(fails: no-unused-vars in current source)*

------
https://chatgpt.com/codex/tasks/task_e_687972a16050832e9aaec1fcfc9f87ba