### PR TITLE
Enhance UI styling and animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,10 @@ export default function App() {
         <Link to="/" className="text-3xl font-bold">Pidoku</Link>
         <div className="ml-auto flex items-center">
           {user && (
-            <Link className="mr-4 underline" to="/profile">
+            <Link
+              className="mr-4 px-3 py-1 rounded bg-blue-200 hover:bg-blue-300 transition"
+              to="/profile"
+            >
               Profile
             </Link>
           )}

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -53,7 +53,10 @@ export default function Game() {
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const [difficulty, setDifficulty] = useState("easy");
-  const [stage, setStage] = useState("select");
+  const initialStage = new URLSearchParams(window.location.search).get("seed")
+    ? "loading"
+    : "select";
+  const [stage, setStage] = useState(initialStage);
   const [puzzleData, setPuzzleData] = useState(null);
   const [board, setBoard] = useState(null);
   const [selected, setSelected] = useState([null, null]);
@@ -67,6 +70,7 @@ export default function Game() {
   const [seedText, setSeedText] = useState("");
   const [seed, setSeed] = useState("");
   const [gameId, setGameId] = useState(null);
+  const [seedCopied, setSeedCopied] = useState(false);
 
   useEffect(() => {
     const seedParam = searchParams.get("seed");
@@ -74,6 +78,8 @@ export default function Game() {
     if (seedParam) {
       loadSeed(seedParam, gameParam);
       setSearchParams({});
+    } else if (stage === "loading") {
+      setStage("select");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -173,6 +179,11 @@ export default function Game() {
     );
   }
 
+  function handleCopySeed() {
+    navigator.clipboard.writeText(seed);
+    setSeedCopied(true);
+  }
+
   async function startPuzzle() {
     let next;
     if (seedInputMode && seedText) {
@@ -262,10 +273,22 @@ export default function Game() {
     }
   }, [completed, correct, user, secondsElapsed, recorded, gameId]);
 
+  useEffect(() => {
+    if (!seedCopied) return;
+    const t = setTimeout(() => setSeedCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [seedCopied]);
+
   const selectedCellNotes =
     board && selected[0] !== null && selected[1] !== null
       ? board[selected[0]][selected[1]].notes
       : [];
+
+  if (stage === "loading") {
+    return (
+      <div className="p-4 text-xl">Loading...</div>
+    );
+  }
 
   return (
     <div className="p-4 flex flex-col items-center">
@@ -280,46 +303,54 @@ export default function Game() {
             className="flex flex-col items-center mt-10"
           >
             <h2 className="text-2xl font-bold mb-4">Choose Difficulty</h2>
-            <div className="flex gap-4 mb-4">
+            <div className="flex flex-wrap items-center gap-4 mb-4">
               {["easy", "medium", "hard"].map((diff) => (
                 <Motion.button
                   key={diff}
                   whileTap={{ scale: 0.9 }}
                   whileHover={{ scale: 1.05 }}
+                  disabled={seedInputMode}
                   onClick={() => setDifficulty(diff)}
-                  className={`px-4 py-2 rounded shadow ${
+                  className={`w-24 px-4 py-2 rounded shadow transition ${
                     difficulty === diff
                       ? "bg-blue-400 text-white"
-                      : "bg-gray-200"
-                  }`}
+                      : "bg-gray-200 hover:bg-gray-300"
+                  } ${seedInputMode ? "opacity-50 cursor-not-allowed" : ""}`}
                 >
                   {diff.charAt(0).toUpperCase() + diff.slice(1)}
                 </Motion.button>
               ))}
+              <div className="flex items-center ml-2 gap-2">
+                <span className="text-sm">Seed</span>
+                <Motion.div
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => setSeedInputMode((s) => !s)}
+                  className={`w-10 h-6 rounded-full bg-gray-300 flex items-center p-1 cursor-pointer ${seedInputMode ? "bg-purple-400" : ""}`}
+                >
+                  <Motion.div
+                    layout
+                    transition={{ type: "spring", stiffness: 700, damping: 30 }}
+                    className="w-4 h-4 bg-white rounded-full shadow"
+                    style={{ x: seedInputMode ? 16 : 0 }}
+                  />
+                </Motion.div>
+                <AnimatePresence>
+                  {seedInputMode && (
+                    <Motion.input
+                      key="seedinput"
+                      initial={{ width: 0, opacity: 0 }}
+                      animate={{ width: 150, opacity: 1 }}
+                      exit={{ width: 0, opacity: 0 }}
+                      transition={{ duration: 0.2 }}
+                      value={seedText}
+                      onChange={(e) => setSeedText(e.target.value)}
+                      placeholder="Enter seed"
+                      className="px-2 py-1 border rounded"
+                    />
+                  )}
+                </AnimatePresence>
+              </div>
             </div>
-            <Motion.button
-              whileTap={{ scale: 0.9 }}
-              whileHover={{ scale: 1.05 }}
-              onClick={() => setSeedInputMode((s) => !s)}
-              className="mb-2 px-4 py-2 bg-purple-200 rounded"
-            >
-              {seedInputMode ? "Cancel Seed" : "Seed"}
-            </Motion.button>
-            <AnimatePresence>
-              {seedInputMode && (
-                <Motion.input
-                  key="seedinput"
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{ duration: 0.2 }}
-                  value={seedText}
-                  onChange={(e) => setSeedText(e.target.value)}
-                  placeholder="Enter seed"
-                  className="px-2 py-1 border rounded mb-2"
-                />
-              )}
-            </AnimatePresence>
             <Motion.button
               whileTap={{ scale: 0.95 }}
               onClick={startPuzzle}
@@ -335,7 +366,7 @@ export default function Game() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="flex flex-col items-center w-full"
+            className="relative flex flex-col items-center w-full"
           >
             <button
               onClick={resetToSelect}
@@ -343,24 +374,38 @@ export default function Game() {
             >
               New Puzzle
             </button>
-            {completed && correct && (
-              <>
-                <Confetti
-                  width={window.innerWidth}
-                  height={window.innerHeight}
-                  numberOfPieces={400}
-                />
-                <div className="mb-4 px-6 py-3 bg-green-200 text-green-800 rounded shadow text-xl font-bold">
+            <AnimatePresence>
+              {completed && correct && (
+                <Motion.div
+                  key="correct"
+                  initial={{ opacity: 0, y: -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  className="absolute -top-12 px-6 py-3 bg-green-200 text-green-800 rounded shadow text-xl font-bold"
+                >
+                  <Confetti
+                    width={window.innerWidth}
+                    height={window.innerHeight}
+                    numberOfPieces={400}
+                  />
                   🎉 You solved it!
-                </div>
-              </>
-            )}
-            {completed && !correct && (
-              <div className="mb-4 px-6 py-3 bg-red-200 text-red-800 rounded shadow text-xl font-bold">
-                Puzzle is filled, but something's wrong!
-              </div>
-            )}
-            <div className="mb-4 text-xl font-mono text-gray-700">Time: {formatTime(secondsElapsed)}</div>
+                </Motion.div>
+              )}
+              {completed && !correct && (
+                <Motion.div
+                  key="wrong"
+                  initial={{ opacity: 0, y: -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  className="absolute -top-12 px-6 py-3 bg-red-200 text-red-800 rounded shadow text-xl font-bold"
+                >
+                  Puzzle is filled, but something's wrong!
+                </Motion.div>
+              )}
+            </AnimatePresence>
+            <div className="mb-4 text-2xl font-mono bg-gray-800 text-white px-4 py-1 rounded shadow">
+              {formatTime(secondsElapsed)}
+            </div>
             {board && (
               <Board
                 board={board}
@@ -378,14 +423,29 @@ export default function Game() {
               />
             )}
             {seed && (
-              <div className="mt-4 flex items-center gap-2 text-sm">
+              <div className="mt-4 flex items-center gap-2 text-sm relative">
                 <span className="font-mono">Seed: {seed}</span>
-                <button
+                <Motion.button
+                  whileTap={{ scale: 0.9 }}
                   className="p-1 bg-gray-200 rounded"
-                  onClick={() => navigator.clipboard.writeText(seed)}
+                  onClick={handleCopySeed}
                 >
                   📋
-                </button>
+                </Motion.button>
+                <AnimatePresence>
+                  {seedCopied && (
+                    <Motion.span
+                      key="copied"
+                      initial={{ opacity: 0, y: -5 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -5 }}
+                      transition={{ duration: 0.3 }}
+                      className="absolute -top-6 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded"
+                    >
+                      Seed copied!
+                    </Motion.span>
+                  )}
+                </AnimatePresence>
               </div>
             )}
           </Motion.div>

--- a/src/Profile.jsx
+++ b/src/Profile.jsx
@@ -44,7 +44,9 @@ export default function Profile() {
               initial={{ opacity: 0, translateY: -5 }}
               animate={{ opacity: 1, translateY: 0 }}
               transition={{ duration: 0.2 }}
-              className="p-2 bg-gray-100 rounded shadow"
+              className={`p-2 rounded shadow ${
+                game.completed ? 'bg-green-100' : 'bg-blue-100'
+              }`}
             >
               <div className="flex justify-between items-center">
                 <div>

--- a/src/components/AuthButtons.jsx
+++ b/src/components/AuthButtons.jsx
@@ -9,23 +9,42 @@ export default function AuthButtons() {
   const [formType, setFormType] = useState('login');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
+  const [showRegisterPrompt, setShowRegisterPrompt] = useState(false);
   const [showForm, setShowForm] = useState(false);
 
   async function handleSubmit(e) {
     e.preventDefault();
     setError('');
+    setShowRegisterPrompt(false);
     try {
       if (formType === 'login') {
         await signInWithEmailAndPassword(auth, email, password);
       } else {
+        if (password !== confirmPassword) {
+          setError('Passwords do not match');
+          return;
+        }
         await createUserWithEmailAndPassword(auth, email, password);
       }
       setEmail('');
       setPassword('');
+      setConfirmPassword('');
       setShowForm(false);
     } catch (err) {
-      setError(err.message);
+      let msg = err.message;
+      if (err.code === 'auth/user-not-found') {
+        msg = 'No account found with this email.';
+        setShowRegisterPrompt(true);
+      } else if (err.code === 'auth/wrong-password') {
+        msg = 'Incorrect password.';
+      } else if (err.code === 'auth/email-already-in-use') {
+        msg = 'Email already in use.';
+      } else if (err.code === 'auth/weak-password') {
+        msg = 'Weak password. Must be at least 6 characters.';
+      }
+      setError(msg);
     }
   }
 
@@ -72,17 +91,63 @@ export default function AuthButtons() {
               onChange={(e) => setPassword(e.target.value)}
               required
             />
+            <AnimatePresence initial={false}>
+              {formType === 'register' && (
+                <Motion.input
+                  key="confirm"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="px-2 py-1 border rounded text-sm"
+                  type="password"
+                  placeholder="repeat password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                />
+              )}
+            </AnimatePresence>
             <button className="px-3 py-1 bg-blue-200 rounded text-sm" type="submit">
               {formType === 'login' ? 'Log In' : 'Register'}
             </button>
             <button
               type="button"
               className="text-xs underline"
-              onClick={() => setFormType(formType === 'login' ? 'register' : 'login')}
+              onClick={() => {
+                setFormType(formType === 'login' ? 'register' : 'login');
+                setError('');
+                setShowRegisterPrompt(false);
+              }}
             >
               {formType === 'login' ? 'Need an account?' : 'Have an account?'}
             </button>
-            {error && <div className="text-xs text-red-600">{error}</div>}
+            <AnimatePresence>
+              {error && (
+                <Motion.div
+                  key="err"
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  className="text-xs text-red-600"
+                >
+                  {error}{' '}
+                  {showRegisterPrompt && (
+                    <button
+                      type="button"
+                      className="underline ml-1"
+                      onClick={() => {
+                        setFormType('register');
+                        setError('');
+                        setShowRegisterPrompt(false);
+                      }}
+                    >
+                      Register now?
+                    </button>
+                  )}
+                </Motion.div>
+              )}
+            </AnimatePresence>
           </Motion.form>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- polish header profile link style
- highlight completed and in-progress games in profile list
- animate auth form with password confirmation and error handling
- update game timer styling and overlay solved/mistake banners
- rework difficulty picker with animated seed toggle
- add animated seed copy popup

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a2bab8cc8832eb66bbb5966813276