### PR TITLE
Configure Vite dev proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 An in-progress web-based sudoku game. Currently single-player, but will have user account, multi-player, etc. soon!
 
+## Development
+
+API calls from the frontend are proxied to a backend running on port `3001`. Start your backend server on that port before running the Vite dev server so that requests to `/api` are forwarded correctly.
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,9 @@ export default defineConfig({
     tailwindcss()
 
   ],
+  server: {
+    proxy: {
+      '/api': { target: 'http://localhost:3001', changeOrigin: true }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- proxy API calls to the backend in `vite.config.js`
- document the backend port requirement in the README

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_687cc2566c38832e9b90fade44a499ca