### PR TITLE
Fix mobile board layout

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -33,8 +33,8 @@ export default function Board({ board, selected, onCellSelect }) {
   }
 
   return (
-    <div className="inline-block bg-gray-200 p-2 rounded-md shadow-lg select-none">
-      <div className="grid grid-cols-9">
+    <div className="inline-block bg-gray-200 p-2 rounded-md shadow-lg select-none w-full">
+      <div className="grid grid-cols-9 w-full">
         {board.map((row, rowIdx) =>
           row.map((cell, colIdx) => (
             <Cell

--- a/src/components/Cell.jsx
+++ b/src/components/Cell.jsx
@@ -48,7 +48,7 @@ export default function Cell({
   const highlight = `${bg} ${text}`;
 
   const base =
-    "w-12 h-12 text-center text-lg cursor-pointer relative flex items-center justify-center";
+    "aspect-square w-full text-center text-lg cursor-pointer relative flex items-center justify-center";
   const border =
     `border 
     ${col % 3 === 0 ? "border-l-4 border-l-gray-400" : "border-l"} 


### PR DESCRIPTION
## Summary
- make puzzle board stretch to container width
- use `aspect-square` for each cell so width equals height

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d23d8f098832eb6f58b0719bab71e