### PR TITLE
Improve progress bar behavior

### DIFF
--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -366,8 +366,9 @@ export default function Game() {
 
   useEffect(() => {
     if (!board) return;
-    const filled = board.flat().filter((c) => c.value).length;
-    setProgress((filled / 81) * 100);
+    const playable = board.flat().filter((c) => !c.fixed);
+    const filled = playable.filter((c) => c.value).length;
+    setProgress((filled / playable.length) * 100);
   }, [board]);
 
   useEffect(() => {
@@ -472,7 +473,7 @@ export default function Game() {
 
   return (
     <div className="p-4 flex flex-col items-center">
-      <BackgroundProgress progress={progress} />
+      {stage === "play" && <BackgroundProgress progress={progress} />}
       <AnimatePresence mode="wait">
         {stage === "select" ? (
           <Motion.div

--- a/src/components/BackgroundProgress.jsx
+++ b/src/components/BackgroundProgress.jsx
@@ -1,7 +1,32 @@
 import React from 'react';
 import PrettyProgressbar from 'pretty-progressbar';
 
+function hexToRgb(hex) {
+  const clean = hex.replace('#', '');
+  const bigint = parseInt(clean, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r, g, b];
+}
+
+function mixColor(a, c, amount) {
+  const [r1, g1, b1] = hexToRgb(a);
+  const [r2, g2, b2] = hexToRgb(c);
+  const r = Math.round(r1 + (r2 - r1) * amount);
+  const g = Math.round(g1 + (g2 - g1) * amount);
+  const b = Math.round(b1 + (b2 - b1) * amount);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
 export default function BackgroundProgress({ progress }) {
+  const ratio = Math.max(0, Math.min(1, progress / 100));
+  const start1 = '#f97316'; // orange
+  const start2 = '#fde047'; // yellow
+  const end1 = '#3b82f6'; // blue
+  const end2 = '#9333ea'; // purple
+  const color1 = mixColor(start1, end1, ratio);
+  const color2 = mixColor(start2, end2, ratio);
   const barStyle = {
     position: 'absolute',
     overflow: 'hidden',
@@ -10,11 +35,11 @@ export default function BackgroundProgress({ progress }) {
     background: 'transparent',
   };
   const progressStyle = {
-    background: 'rgba(59, 130, 246, 0.2)',
+    background: `linear-gradient(135deg, ${color1}, ${color2})`,
     transition: 'transform 0.3s linear',
     backgroundSize: '200% 200%',
-    animation: 'gradient-wave 6s ease-in-out infinite',
-    boxShadow: '0 0 20px rgba(59, 130, 246, 0.5)',
+    animation: 'aceternity-gradient 6s ease-in-out infinite',
+    boxShadow: `0 0 20px ${color1}`,
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,18 @@
   }
 }
 
+@keyframes aceternity-gradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .progress-wave {
   background: linear-gradient(90deg, rgba(59, 130, 246, 0.4), rgba(99, 102, 241, 0.4), rgba(59, 130, 246, 0.4));
   background-size: 200% 200%;


### PR DESCRIPTION
## Summary
- animate the progress bar background with a gradient
- transition colors from orange/yellow to blue/purple as progress increases
- hide progress bar on the select screen
- compute progress based only on user-filled cells

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688890e89834832e9d84a62eb908f7f8