### PR TITLE
Fix background progress behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col ml-0 ">
-      <header className="p-4 flex items-center shadow bg-white">
+      <header className="sticky top-0 z-10 p-4 flex items-center shadow bg-white">
         <Link to="/" className="text-3xl font-bold">Pidoku</Link>
         <div className="ml-auto flex items-center">
           {user && (

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -115,6 +115,7 @@ export default function Game() {
   const [gameId, setGameId] = useState(null);
   const [seedCopied, setSeedCopied] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [initialEmptyCells, setInitialEmptyCells] = useState(0);
   const [joinCode, setJoinCode] = useState("");
   const joinInputControls = useAnimationControls();
 
@@ -199,6 +200,10 @@ export default function Game() {
       const gdata = await resGame.json();
       setGameId(gdata.id);
     }
+    const emptyCount = puzzle.flat().filter((c) => !c.fixed).length;
+    const placedCount = boardData.flat().filter((c) => c.value && !c.fixed).length;
+    setInitialEmptyCells(emptyCount);
+    setProgress((placedCount / emptyCount) * 100);
     setBoard(boardData);
     setSecondsElapsed(secs);
     setSelected([null, null]);
@@ -328,6 +333,9 @@ export default function Game() {
         }))
       )
     );
+    const emptyCount = boardData.flat().filter((c) => !c.fixed).length;
+    setInitialEmptyCells(emptyCount);
+    setProgress(0);
     setBoard(boardData);
     setSelected([null, null]);
     setCompleted(false);
@@ -375,11 +383,15 @@ export default function Game() {
   }
 
   function resetToSelect() {
-    setStage("select");
-    setBoard(null);
-    setPuzzleData(null);
-    setSeed("");
-    setGameId(null);
+    setProgress(0);
+    setInitialEmptyCells(0);
+    setTimeout(() => {
+      setStage("select");
+      setBoard(null);
+      setPuzzleData(null);
+      setSeed("");
+      setGameId(null);
+    }, 300);
   }
 
   useEffect(() => {
@@ -401,9 +413,9 @@ export default function Game() {
 
   useEffect(() => {
     if (!board) return;
-    const filled = board.flat().filter((c) => c.value).length;
-    setProgress((filled / 81) * 100);
-  }, [board]);
+    const placed = board.flat().filter((c) => c.value && !c.fixed).length;
+    setProgress(initialEmptyCells ? (placed / initialEmptyCells) * 100 : 0);
+  }, [board, initialEmptyCells]);
 
   useEffect(() => {
     if (!timerActive) return;
@@ -507,7 +519,7 @@ export default function Game() {
 
   return (
     <div className="p-4 flex flex-col items-center">
-      <BackgroundProgress progress={progress} />
+      {stage === "play" && <BackgroundProgress progress={progress} />}
       <AnimatePresence mode="popLayout">
         {stage === "select" ? (
         <Motion.div

--- a/src/components/BackgroundProgress.jsx
+++ b/src/components/BackgroundProgress.jsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PrettyProgressbar from 'pretty-progressbar';
 
 export default function BackgroundProgress({ progress }) {
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const header = document.querySelector('header');
+    if (header) setOffset(header.offsetHeight);
+  }, []);
+
   const barStyle = {
     position: 'absolute',
     overflow: 'hidden',
@@ -18,7 +25,10 @@ export default function BackgroundProgress({ progress }) {
   };
 
   return (
-    <div className="fixed inset-0 z-0 pointer-events-none">
+    <div
+      className="fixed inset-x-0 z-0 pointer-events-none"
+      style={{ top: offset, bottom: 0 }}
+    >
       <PrettyProgressbar
         percentage={progress}
         label={false}


### PR DESCRIPTION
## Summary
- track only user-placed cells for background progress
- keep progress bar below header and reset between games

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d7966784832eb929a2a03425b643